### PR TITLE
Added support to acf_the_content hook for images and videos. I am asu…

### DIFF
--- a/classes/class-a3-lazy-load.php
+++ b/classes/class-a3-lazy-load.php
@@ -70,6 +70,10 @@ class A3_Lazy_Load
 
 			if ( $a3_lazy_load_global_settings['a3l_apply_image_to_content'] == true ) {
 				add_filter( 'the_content', array( $this, 'filter_content_images' ), 10 );
+				// We are asuming the user doesn't care about the difference between a regular WP content
+				// and the ACF text and Wysiwyg areas
+				add_filter( 'acf_the_content', array( $this, 'filter_content_images' ), 10 );
+
 			}
 			if ( $a3_lazy_load_global_settings['a3l_apply_image_to_textwidget'] == true ) {
 				add_filter( 'widget_text', array( $this, 'filter_images' ), 200 );
@@ -98,6 +102,9 @@ class A3_Lazy_Load
 
 			if ( $a3_lazy_load_global_settings['a3l_apply_video_to_content'] == true ) {
 				add_filter( 'the_content', array( $this, 'filter_videos' ), 10 );
+				// We are asuming the user doesn't care about the difference between a regular WP content
+				// and the ACF text and Wysiwyg areas
+				add_filter( 'acf_the_content', array( $this, 'filter_videos' ), 10 );
 			}
 			if ( $a3_lazy_load_global_settings['a3l_apply_video_to_textwidget'] == true ) {
 				add_filter( 'widget_text', array( $this, 'filter_videos' ), 200 );


### PR DESCRIPTION
I haven't updated the readme. I have tested this locally before opening the support ticket and it works flawlesly for images, videos and iframe giphys (which in the end are just videos).