### PR TITLE
Allow `.*` to be used in the skipped class list as a wildcard

### DIFF
--- a/classes/class-a3-lazy-load.php
+++ b/classes/class-a3-lazy-load.php
@@ -226,6 +226,11 @@ class A3_Lazy_Load
 		return false;
 	}
 
+	static public function preg_quote_with_wildcards($what){
+		// Perform preg_quote, but still allow `.*` to be used in the class list as a wildcard.
+		return str_replace('\.\*','.*',preg_quote($what, '/'));
+	}
+
 	static function add_lazy_attributes( $allowedposttags, $context ) {
 
 		if ( 'post' === $context && ! empty( $allowedposttags ) ) {
@@ -357,11 +362,6 @@ class A3_Lazy_Load
 		return $attr;
 	}
 
-	static function preg_quote_with_wildcards($string){
-		// Perform preg_quote, but still allow `.*` to be used in the class list as a wildcard.
-		return str_replace('\.\*','.*',preg_quote($string));
-	}
-
 	protected function _filter_images( $content, $include_noscript = null ) {
 
 		if ( null === $include_noscript ) {
@@ -383,10 +383,10 @@ class A3_Lazy_Load
 
 		$i = 0;
 		foreach ( $matches[0] as $imgHTML ) {
-
 			// don't to the replacement if a skip class is provided and the image has the class, or if the image is a data-uri
 			if ( ! ( is_array( $this->_skip_images_classes ) && preg_match( $skip_images_regex, $imgHTML ) ) && ! preg_match( "/src=['\"]data:image/is", $imgHTML ) && ! preg_match( "/src=.*lazy_placeholder.gif['\"]/s", $imgHTML ) ) {
 				$i++;
+
 				// replace the src and add the data-src attribute
 				$replaceHTML = '';
 				$replaceHTML = preg_replace( '/<img(.*?)src=/is', '<img$1src="' . $this->_placeholder_url . '" data-lazy-type="image" data-src=', $imgHTML );
@@ -425,7 +425,7 @@ class A3_Lazy_Load
 
 		return $return;
 	}
- 
+
 	static function filter_videos( $content, $include_noscript = null ) {
 		if ( is_admin() ) {
 			return $content;
@@ -481,7 +481,7 @@ class A3_Lazy_Load
 		$replace = array();
 
 		if ( is_array( $this->_skip_videos_classes ) ) {
-			$skip_images_preg_quoted = array_map( 'preg_quote_with_wildcards', $this->_skip_videos_classes );
+			$skip_images_preg_quoted = array_map( 'preg_quote', $this->_skip_videos_classes );
 			$skip_images_regex = sprintf( '/class=".*(%s).*"/s', implode( '|', $skip_images_preg_quoted ) );
 		}
 
@@ -527,7 +527,7 @@ class A3_Lazy_Load
 		$replace = array();
 
 		if ( is_array( $this->_skip_videos_classes ) ) {
-			$skip_images_preg_quoted = array_map( 'preg_quote_with_wildcards', $this->_skip_videos_classes );
+			$skip_images_preg_quoted = array_map( 'preg_quote', $this->_skip_videos_classes );
 			$skip_images_regex = sprintf( '/class=".*(%s).*"/s', implode( '|', $skip_images_preg_quoted ) );
 		}
 
@@ -575,7 +575,7 @@ class A3_Lazy_Load
 		$replace = array();
 
 		if ( is_array( $this->_skip_videos_classes ) ) {
-			$skip_images_preg_quoted = array_map( 'preg_quote_with_wildcards', $this->_skip_videos_classes );
+			$skip_images_preg_quoted = array_map( 'preg_quote', $this->_skip_videos_classes );
 			$skip_images_regex = sprintf( '/class=".*(%s).*"/s', implode( '|', $skip_images_preg_quoted ) );
 		}
 

--- a/classes/class-a3-lazy-load.php
+++ b/classes/class-a3-lazy-load.php
@@ -337,7 +337,7 @@ class A3_Lazy_Load
 		$A3_Lazy_Load = A3_Lazy_Load::_instance();
 
 		if ( is_array( $A3_Lazy_Load->_skip_images_classes ) ) {
-			$skip_images_preg_quoted = array_map( 'preg_quote', $A3_Lazy_Load->_skip_images_classes );
+			$skip_images_preg_quoted = array_map( 'preg_quote_with_wildcards', $A3_Lazy_Load->_skip_images_classes );
 			$skip_images_regex = sprintf( '/class=".*(%s).*"/s', implode( '|', $skip_images_preg_quoted ) );
 		}
 
@@ -357,6 +357,11 @@ class A3_Lazy_Load
 		return $attr;
 	}
 
+	static function preg_quote_with_wildcards($string){
+		// Perform preg_quote, but still allow `.*` to be used in the class list as a wildcard.
+		return str_replace('\.\*','.*',preg_quote($string));
+	}
+
 	protected function _filter_images( $content, $include_noscript = null ) {
 
 		if ( null === $include_noscript ) {
@@ -372,7 +377,7 @@ class A3_Lazy_Load
 		$replace = array();
 
 		if ( is_array( $this->_skip_images_classes ) ) {
-			$skip_images_preg_quoted = array_map( 'preg_quote', $this->_skip_images_classes );
+			$skip_images_preg_quoted = array_map( 'preg_quote_with_wildcards', $this->_skip_images_classes );
 			$skip_images_regex = sprintf( '/class=".*(%s).*"/s', implode( '|', $skip_images_preg_quoted ) );
 		}
 
@@ -476,7 +481,7 @@ class A3_Lazy_Load
 		$replace = array();
 
 		if ( is_array( $this->_skip_videos_classes ) ) {
-			$skip_images_preg_quoted = array_map( 'preg_quote', $this->_skip_videos_classes );
+			$skip_images_preg_quoted = array_map( 'preg_quote_with_wildcards', $this->_skip_videos_classes );
 			$skip_images_regex = sprintf( '/class=".*(%s).*"/s', implode( '|', $skip_images_preg_quoted ) );
 		}
 
@@ -522,7 +527,7 @@ class A3_Lazy_Load
 		$replace = array();
 
 		if ( is_array( $this->_skip_videos_classes ) ) {
-			$skip_images_preg_quoted = array_map( 'preg_quote', $this->_skip_videos_classes );
+			$skip_images_preg_quoted = array_map( 'preg_quote_with_wildcards', $this->_skip_videos_classes );
 			$skip_images_regex = sprintf( '/class=".*(%s).*"/s', implode( '|', $skip_images_preg_quoted ) );
 		}
 
@@ -570,7 +575,7 @@ class A3_Lazy_Load
 		$replace = array();
 
 		if ( is_array( $this->_skip_videos_classes ) ) {
-			$skip_images_preg_quoted = array_map( 'preg_quote', $this->_skip_videos_classes );
+			$skip_images_preg_quoted = array_map( 'preg_quote_with_wildcards', $this->_skip_videos_classes );
 			$skip_images_regex = sprintf( '/class=".*(%s).*"/s', implode( '|', $skip_images_preg_quoted ) );
 		}
 


### PR DESCRIPTION
This still performs preg_quote, but it selectively allows `.*` to be used in the skipped class list as a wildcard.

As an aside, I've posted about this on the WP.org support forum at: https://wordpress.org/support/topic/proposed-patch-allow-to-be-used-in-the-skipped-class-list-as-a-wildcard/