### PR TITLE
Prevent Conflict with Jetpack’s Photon/WP.com Image CDN feature’s devicepx JavaScript

### DIFF
--- a/classes/class-a3-lazy-load.php
+++ b/classes/class-a3-lazy-load.php
@@ -168,6 +168,9 @@ class A3_Lazy_Load
 
 		wp_enqueue_script( 'jquery-lazyloadxt-extend' );
 
+		// Disable Jetpack's devicepx (has a conflict with a3 Lazy Load [retains the placeholder as the higher-dpi image asset via srcset])
+		wp_dequeue_script( 'devicepx' );
+
 		$A3_Lazy_Load = A3_Lazy_Load::_instance();
 
 		$A3_Lazy_Load->localize_printed_scripts();


### PR DESCRIPTION
Just putting this out there as a possible resolution to https://github.com/a3rev/a3-lazy-load/issues/34.

There may be better solutions available, but I'm not familiar enough with the plugin to know what might be the more desirable option (I just know that this prevents a conflict which makes the whole purpose of devicepx break when a3 Lazy Load is enabled for images [it just keeps the placeholder image shown as the issue referenced above mentions.])