### PR TITLE
Release 2.7.9 — admin framework hardening

### DIFF
--- a/a3-lazy-load.php
+++ b/a3-lazy-load.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: a3 Lazy Load
 Description: Speed up your site and enhance frontend user's visual experience in PC's, Tablets and mobile with a3 Lazy Load.
-Version: 2.7.8
+Version: 2.7.9
 Author: a3rev Software
 Author URI: https://a3rev.com/
 Requires at least: 6.0
@@ -31,7 +31,7 @@ define('A3_LAZY_LOAD_IMAGES_URL', A3_LAZY_LOAD_URL . '/assets/images');
 
 define( 'A3_LAZY_LOAD_KEY', 'a3_lazy_load' );
 define( 'A3_LAZY_LOAD_PREFIX', 'a3_lazy_load_' );
-define( 'A3_LAZY_VERSION', '2.7.8' );
+define( 'A3_LAZY_VERSION', '2.7.9' );
 define( 'A3_LAZY_LOAD_G_FONTS', false );
 
 use \A3Rev\LazyLoad\FrameWork;

--- a/admin/admin-interface.php
+++ b/admin/admin-interface.php
@@ -51,7 +51,6 @@ class Admin_Interface extends Admin_UI
 
 		// AJAX hide yellow message dontshow
 		add_action( 'wp_ajax_'.$this->plugin_name.'_a3_admin_ui_event', array( $this, 'a3_admin_ui_event' ) );
-		add_action( 'wp_ajax_nopriv_'.$this->plugin_name.'_a3_admin_ui_event', array( $this, 'a3_admin_ui_event' ) );
 
 	}
 
@@ -173,6 +172,9 @@ class Admin_Interface extends Admin_UI
 
 	public function a3_admin_ui_event() {
 		check_ajax_referer( $this->plugin_name. '_a3_admin_ui_event', 'security' );
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( -1, 403 );
+		}
 		if ( isset( $_REQUEST['type'] ) ) {
 			switch ( trim( sanitize_text_field( wp_unslash( $_REQUEST['type'] ) ) ) ) {
 				case 'open_close_panel_box':
@@ -194,8 +196,7 @@ class Admin_Interface extends Admin_UI
 					break;
 
 				case 'check_new_version':
-					$transient_name = sanitize_key( wp_unslash( $_REQUEST['transient_name'] ) );
-					delete_transient( $transient_name );
+					delete_transient( $this->version_transient );
 
 					$new_version = '';
 

--- a/admin/admin-ui.php
+++ b/admin/admin-ui.php
@@ -147,7 +147,6 @@ class Admin_UI
 		if ( ! empty( $g_key ) ) {
 			$respone_api = wp_remote_get( "https://maps.googleapis.com/maps/api/geocode/json?address=Australia&key=" . $g_key,
 				array(
-					'sslverify' => false,
 					'timeout'   => 45
 				)
 			);
@@ -157,7 +156,7 @@ class Admin_UI
 			// Check it is a valid request
 			if ( ! is_wp_error( $respone_api ) ) {
 
-				$json_string = version_compare( PHP_VERSION, '7.4', '>=' ) || get_magic_quotes_gpc() ? stripslashes( $respone_api['body'] ) : $respone_api['body']; // @codingStandardsIgnoreLine // phpcs:ignore
+				$json_string = stripslashes( $respone_api['body'] );
 				$response_map = json_decode( $json_string, true );
 
 				// Make sure that the valid response from google is not an error message

--- a/admin/includes/fonts_face.php
+++ b/admin/includes/fonts_face.php
@@ -438,7 +438,6 @@ class Fonts_Face extends Admin_UI
 		if ( ! empty( $g_key ) ) {
 			$respone_api = wp_remote_get( "https://www.googleapis.com/webfonts/v1/webfonts?sort=alpha&key=" . $g_key,
 				array(
-					'sslverify' => false,
 					'timeout'   => 45
 				)
 			);
@@ -446,7 +445,7 @@ class Fonts_Face extends Admin_UI
 			// Check it is a valid request
 			if ( ! is_wp_error( $respone_api ) ) {
 
-				$json_string = version_compare( PHP_VERSION, '7.4', '>=' ) || get_magic_quotes_gpc() ? stripslashes( $respone_api['body'] ) : $respone_api['body']; // @codingStandardsIgnoreLine // phpcs:ignore
+				$json_string = stripslashes( $respone_api['body'] );
 				$response_fonts = json_decode( $json_string, true );
 			}
 		}
@@ -494,7 +493,7 @@ class Fonts_Face extends Admin_UI
 					$response = wp_remote_get( $this->admin_plugin_url() . '/assets/webfonts/webfonts.json', array( 'timeout' => 120 ) );
 					$webfonts = wp_remote_retrieve_body( $response );
 					if ( ! empty( $webfonts ) ) {
-						$json_string = version_compare( PHP_VERSION, '7.4', '>=' ) || get_magic_quotes_gpc() ? stripslashes( $webfonts ) : $webfonts; // @codingStandardsIgnoreLine // phpcs:ignore
+						$json_string = stripslashes( $webfonts );
 						$response_fonts = json_decode( $json_string, true );
 					}
 				}
@@ -548,7 +547,7 @@ class Fonts_Face extends Admin_UI
 					$response = wp_remote_get( $this->admin_plugin_url() . '/assets/webfonts/webfonts.json', array( 'timeout' => 120 ) );
 					$webfonts = wp_remote_retrieve_body( $response );
 					if ( ! empty( $webfonts ) ) {
-						$json_string = version_compare( PHP_VERSION, '7.4', '>=' ) || get_magic_quotes_gpc() ? stripslashes( $webfonts ) : $webfonts; // @codingStandardsIgnoreLine // phpcs:ignore
+						$json_string = stripslashes( $webfonts );
 						$response_fonts = json_decode( $json_string, true );
 					}
 				}

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: a3rev, a3rev Software, nguyencongtuan
 Tags: a3 lazy load, Lazy Loading, image lazy load, lazyload
 Requires at least: 6.0
 Tested up to: 7.0
-Stable tag: 2.7.8
+Stable tag: 2.7.9
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -201,6 +201,10 @@ Filter tags to add to class name of theme to exclude lazy load on images or vide
 
 
 == Changelog ==
+
+= 2.7.9 - 2026/06/29 =
+* This release contains an important security fix - please update right away.
+* Security - Hardened the admin settings AJAX handler and tightened outbound API requests.
 
 = 2.7.8 - 2026/05/07 =
 * This release contains an important security fix - please update right away.
@@ -665,6 +669,9 @@ Filter tags to add to class name of theme to exclude lazy load on images or vide
 
 
 == Upgrade Notice ==
+
+= 2.7.9 =
+Important security fix. Please upgrade now.
 
 = 2.7.8 =
 Important security fix. Please upgrade now.


### PR DESCRIPTION
## Summary

Maintenance/hardening release **2.7.9** for the shared a3rev admin settings framework. Public repo — wording kept generic per coordinated disclosure.

- **Admin AJAX handler (`a3_admin_ui_event`)** — require `current_user_can( 'manage_options' )` after the nonce check, and remove the `wp_ajax_nopriv_*` registration so the handler is admin-only.
- **Version-check transient** — delete the plugin's own `$this->version_transient` instead of a request-supplied transient name.
- **Outbound Google API requests** — enable TLS certificate verification (drop `'sslverify' => false`) in the Maps geocode and Webfonts lookups.
- **Cleanup** — remove the dead `get_magic_quotes_gpc()` compatibility shim (function removed in PHP 8.0) in favour of plain `stripslashes()`.

Mirrors the framework fix shipped in `page-views-count` (PR #28) / `woocommerce-quotes-and-orders` (PR #19).

## Version bump
`2.7.8 → 2.7.9` — plugin header, `A3_LAZY_VERSION`, `readme.txt` Stable tag + Changelog + Upgrade Notice.

## Testing
- `php -l` clean on all touched files (`admin/admin-interface.php`, `admin/admin-ui.php`, `admin/includes/fonts_face.php`).
- Change is surgical; frontend lazy-load behaviour unaffected (admin-only framework code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)